### PR TITLE
Add ability to use a proxy

### DIFF
--- a/tool.py
+++ b/tool.py
@@ -49,6 +49,12 @@ from transformers import AutoTokenizer, AutoModelForMaskedLM
 from duckduckgo_search import DDGS
 from duckduckgo_search.utils import json_loads
 from duckduckgo_search.exceptions import DuckDuckGoSearchException
+from open_webui.env import BASE_DIR
+try:
+    from dotenv import find_dotenv, load_dotenv
+    load_dotenv(find_dotenv(str(BASE_DIR / ".env")))
+except ImportError:
+    print("dotenv not installed, skipping...")
 
 
 class AsyncDDGS(DDGS):

--- a/tool.py
+++ b/tool.py
@@ -1581,7 +1581,7 @@ class BM25Retriever:
 
 async def async_download_html(url: str, headers: Dict, timeout: int, proxy: str = None,
                               proxy_except_domains : tuple[str] = None):
-    if proxy_except_domains and url.endswith(proxy_except_domains):
+    if proxy_except_domains and urlparse(url).netloc.endswith(proxy_except_domains):
         proxy = None
     async with aiohttp.ClientSession(headers=headers, timeout=aiohttp.ClientTimeout(timeout),
                                      max_field_size=65536, proxy=proxy) as session:

--- a/tool.py
+++ b/tool.py
@@ -1,6 +1,6 @@
 """
 LLM Web Search
-version: 0.3.4
+version: 0.4.0
 
 Copyright (C) 2024 mamei16
 

--- a/tool.py
+++ b/tool.py
@@ -570,7 +570,8 @@ class DocumentRetriever:
                                                            separators=["\n\n", "\n", ".", ", ", " ", ""])
 
         await emit_status(event_emitter, "Downloading and chunking webpages...", False)
-        split_docs = await async_fetch_chunk_websites(url_list, text_splitter, self.client_timeout, self.proxy)
+        split_docs = await async_fetch_chunk_websites(url_list, text_splitter, self.client_timeout, self.proxy,
+                                                      self.proxy_except_domains)
 
         await emit_status(event_emitter, "Retrieving relevant results...", False)
         if self.ensemble_weighting > 0:


### PR DESCRIPTION
This PR adds support for using a proxy to both fetch search results from Duckduckgo and download result websites. The implementation adheres to the proxy settings available for the main webui, as described in the [open webui documentation](https://docs.openwebui.com/getting-started/env-configuration#proxy-settings).

Closes #7 